### PR TITLE
Supply doubling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build/
 coverage/
 coverage.json
 *.log
+.secret

--- a/contracts/Bond.sol
+++ b/contracts/Bond.sol
@@ -7,7 +7,7 @@ contract Bond is ERC20Burnable, Ownable, Operator {
     /**
      * @notice Constructs the Basis Bond ERC-20 contract.
      */
-    constructor() public ERC20('BAB', 'BAB') {}
+    constructor() public ERC20('BSB', 'BSB') {}
 
     /**
      * @notice Operator mints basis bonds to a recipient

--- a/contracts/Cash.sol
+++ b/contracts/Cash.sol
@@ -7,7 +7,7 @@ contract Cash is ERC20Burnable, Operator {
     /**
      * @notice Constructs the Basis Cash ERC-20 contract.
      */
-    constructor() public ERC20('BAC', 'BAC') {
+    constructor() public ERC20('BSC', 'BSC') {
         // Mints 1 Basis Cash to contract creator for initial Uniswap oracle deployment.
         // Will be burned after oracle deployment
         _mint(msg.sender, 1 * 10**18);

--- a/contracts/Share.sol
+++ b/contracts/Share.sol
@@ -4,7 +4,7 @@ import './owner/Operator.sol';
 import '@openzeppelin/contracts/token/ERC20/ERC20Burnable.sol';
 
 contract Share is ERC20Burnable, Operator {
-    constructor() public ERC20('BAS', 'BAS') {
+    constructor() public ERC20('BSS', 'BSS') {
         // Mints 1 Basis Share to contract creator for initial Uniswap oracle deployment.
         // Will be burned after oracle deployment
         _mint(msg.sender, 1 * 10**18);

--- a/contracts/Treasury.sol
+++ b/contracts/Treasury.sol
@@ -157,6 +157,12 @@ contract Treasury is ContractGuard, Operator {
 
         uint256 cashSupply = IERC20(cash).totalSupply().sub(seigniorageSaved);
         uint256 percentage = cashPrice.sub(cashPriceOne);
+        
+        // Fix: At most double the supply to smooth out the market
+        if (percentage > cashPriceOne) {
+            percentage = cashPriceOne;
+        }
+
         uint256 seigniorage = cashSupply.mul(percentage).div(1e18);
 
         if (seigniorageSaved > bondDepletionFloor) {

--- a/contracts/distribution/BSCDAIPool.sol
+++ b/contracts/distribution/BSCDAIPool.sol
@@ -10,7 +10,7 @@ pragma solidity ^0.6.0;
 /___/ \_, //_//_/\__//_//_/\__/ \__//_/ /_\_\
      /___/
 
-* Synthetix: BASISCASHRewards.sol
+* Synthetix: BSSISCASHRewards.sol
 *
 * Docs: https://docs.synthetix.io/
 *
@@ -62,11 +62,11 @@ import '@openzeppelin/contracts/token/ERC20/SafeERC20.sol';
 
 import '../interfaces/IRewardDistributionRecipient.sol';
 
-contract SUSDWrapper {
+contract DAIWrapper {
     using SafeMath for uint256;
     using SafeERC20 for IERC20;
 
-    IERC20 public SUSD;
+    IERC20 public dai;
 
     uint256 private _totalSupply;
     mapping(address => uint256) private _balances;
@@ -82,17 +82,17 @@ contract SUSDWrapper {
     function stake(uint256 amount) public virtual {
         _totalSupply = _totalSupply.add(amount);
         _balances[msg.sender] = _balances[msg.sender].add(amount);
-        SUSD.safeTransferFrom(msg.sender, address(this), amount);
+        dai.safeTransferFrom(msg.sender, address(this), amount);
     }
 
     function withdraw(uint256 amount) public virtual {
         _totalSupply = _totalSupply.sub(amount);
         _balances[msg.sender] = _balances[msg.sender].sub(amount);
-        SUSD.safeTransfer(msg.sender, amount);
+        dai.safeTransfer(msg.sender, amount);
     }
 }
 
-contract BACSUSDPool is SUSDWrapper, IRewardDistributionRecipient {
+contract BSCDAIPool is DAIWrapper, IRewardDistributionRecipient {
     IERC20 public basisCash;
     uint256 public DURATION = 5 days;
 
@@ -112,16 +112,16 @@ contract BACSUSDPool is SUSDWrapper, IRewardDistributionRecipient {
 
     constructor(
         address basisCash_,
-        address susd_,
+        address dai_,
         uint256 starttime_
     ) public {
         basisCash = IERC20(basisCash_);
-        SUSD = IERC20(susd_);
+        dai = IERC20(dai_);
         starttime = starttime_;
     }
 
     modifier checkStart() {
-        require(block.timestamp >= starttime, 'BACSUSDPool: not start');
+        require(block.timestamp >= starttime, 'BSCDAIPool: not start');
         _;
     }
 
@@ -168,11 +168,11 @@ contract BACSUSDPool is SUSDWrapper, IRewardDistributionRecipient {
         updateReward(msg.sender)
         checkStart
     {
-        require(amount > 0, 'BACSUSDPool: Cannot stake 0');
+        require(amount > 0, 'BSCDAIPool: Cannot stake 0');
         uint256 newDeposit = deposits[msg.sender].add(amount);
         require(
             newDeposit <= 20000e18,
-            'BACSUSDPool: deposit amount exceeds maximum 20000'
+            'BSCDAIPool: deposit amount exceeds maximum 20000'
         );
         deposits[msg.sender] = newDeposit;
         super.stake(amount);
@@ -185,7 +185,7 @@ contract BACSUSDPool is SUSDWrapper, IRewardDistributionRecipient {
         updateReward(msg.sender)
         checkStart
     {
-        require(amount > 0, 'BACSUSDPool: Cannot withdraw 0');
+        require(amount > 0, 'BSCDAIPool: Cannot withdraw 0');
         deposits[msg.sender] = deposits[msg.sender].sub(amount);
         super.withdraw(amount);
         emit Withdrawn(msg.sender, amount);

--- a/contracts/distribution/BSCDAIPool.sol
+++ b/contracts/distribution/BSCDAIPool.sol
@@ -10,7 +10,7 @@ pragma solidity ^0.6.0;
 /___/ \_, //_//_/\__//_//_/\__/ \__//_/ /_\_\
      /___/
 
-* Synthetix: BSSISCASHRewards.sol
+* Synthetix: BASISCASHRewards.sol
 *
 * Docs: https://docs.synthetix.io/
 *

--- a/contracts/distribution/BSCSUSDPool.sol
+++ b/contracts/distribution/BSCSUSDPool.sol
@@ -10,7 +10,7 @@ pragma solidity ^0.6.0;
 /___/ \_, //_//_/\__//_//_/\__/ \__//_/ /_\_\
      /___/
 
-* Synthetix: BSSISCASHRewards.sol
+* Synthetix: BASISCASHRewards.sol
 *
 * Docs: https://docs.synthetix.io/
 *

--- a/contracts/distribution/BSCUSDCPool.sol
+++ b/contracts/distribution/BSCUSDCPool.sol
@@ -10,7 +10,7 @@ pragma solidity ^0.6.0;
 /___/ \_, //_//_/\__//_//_/\__/ \__//_/ /_\_\
      /___/
 
-* Synthetix: BASISCASHRewards.sol
+* Synthetix: BSSISCASHRewards.sol
 *
 * Docs: https://docs.synthetix.io/
 *
@@ -92,7 +92,7 @@ contract USDCWrapper {
     }
 }
 
-contract BACUSDCPool is USDCWrapper, IRewardDistributionRecipient {
+contract BSCUSDCPool is USDCWrapper, IRewardDistributionRecipient {
     IERC20 public basisCash;
     uint256 public DURATION = 5 days;
 
@@ -121,7 +121,7 @@ contract BACUSDCPool is USDCWrapper, IRewardDistributionRecipient {
     }
 
     modifier checkStart() {
-        require(block.timestamp >= starttime, 'BACUSDCPool: not start');
+        require(block.timestamp >= starttime, 'BSCUSDCPool: not start');
         _;
     }
 
@@ -168,11 +168,11 @@ contract BACUSDCPool is USDCWrapper, IRewardDistributionRecipient {
         updateReward(msg.sender)
         checkStart
     {
-        require(amount > 0, 'BACUSDCPool: Cannot stake 0');
+        require(amount > 0, 'BSCUSDCPool: Cannot stake 0');
         uint256 newDeposit = deposits[msg.sender].add(amount);
         require(
             newDeposit <= 20000e6,
-            'BACUSDCPool: deposit amount exceeds maximum 20000'
+            'BSCUSDCPool: deposit amount exceeds maximum 20000'
         );
         deposits[msg.sender] = newDeposit;
         super.stake(amount);
@@ -185,7 +185,7 @@ contract BACUSDCPool is USDCWrapper, IRewardDistributionRecipient {
         updateReward(msg.sender)
         checkStart
     {
-        require(amount > 0, 'BACUSDCPool: Cannot withdraw 0');
+        require(amount > 0, 'BSCUSDCPool: Cannot withdraw 0');
         deposits[msg.sender] = deposits[msg.sender].sub(amount);
         super.withdraw(amount);
         emit Withdrawn(msg.sender, amount);

--- a/contracts/distribution/BSCUSDCPool.sol
+++ b/contracts/distribution/BSCUSDCPool.sol
@@ -10,7 +10,7 @@ pragma solidity ^0.6.0;
 /___/ \_, //_//_/\__//_//_/\__/ \__//_/ /_\_\
      /___/
 
-* Synthetix: BSSISCASHRewards.sol
+* Synthetix: BASISCASHRewards.sol
 *
 * Docs: https://docs.synthetix.io/
 *

--- a/contracts/distribution/BSCUSDTPool.sol
+++ b/contracts/distribution/BSCUSDTPool.sol
@@ -10,7 +10,7 @@ pragma solidity ^0.6.0;
 /___/ \_, //_//_/\__//_//_/\__/ \__//_/ /_\_\
      /___/
 
-* Synthetix: BASISCASHRewards.sol
+* Synthetix: BSSISCASHRewards.sol
 *
 * Docs: https://docs.synthetix.io/
 *
@@ -62,11 +62,11 @@ import '@openzeppelin/contracts/token/ERC20/SafeERC20.sol';
 
 import '../interfaces/IRewardDistributionRecipient.sol';
 
-contract DAIWrapper {
+contract USDTWrapper {
     using SafeMath for uint256;
     using SafeERC20 for IERC20;
 
-    IERC20 public dai;
+    IERC20 public usdt;
 
     uint256 private _totalSupply;
     mapping(address => uint256) private _balances;
@@ -82,17 +82,17 @@ contract DAIWrapper {
     function stake(uint256 amount) public virtual {
         _totalSupply = _totalSupply.add(amount);
         _balances[msg.sender] = _balances[msg.sender].add(amount);
-        dai.safeTransferFrom(msg.sender, address(this), amount);
+        usdt.safeTransferFrom(msg.sender, address(this), amount);
     }
 
     function withdraw(uint256 amount) public virtual {
         _totalSupply = _totalSupply.sub(amount);
         _balances[msg.sender] = _balances[msg.sender].sub(amount);
-        dai.safeTransfer(msg.sender, amount);
+        usdt.safeTransfer(msg.sender, amount);
     }
 }
 
-contract BACDAIPool is DAIWrapper, IRewardDistributionRecipient {
+contract BSCUSDTPool is USDTWrapper, IRewardDistributionRecipient {
     IERC20 public basisCash;
     uint256 public DURATION = 5 days;
 
@@ -112,16 +112,16 @@ contract BACDAIPool is DAIWrapper, IRewardDistributionRecipient {
 
     constructor(
         address basisCash_,
-        address dai_,
+        address usdt_,
         uint256 starttime_
     ) public {
         basisCash = IERC20(basisCash_);
-        dai = IERC20(dai_);
+        usdt = IERC20(usdt_);
         starttime = starttime_;
     }
 
     modifier checkStart() {
-        require(block.timestamp >= starttime, 'BACDAIPool: not start');
+        require(block.timestamp >= starttime, 'BSCUSDTPool: not start');
         _;
     }
 
@@ -168,11 +168,11 @@ contract BACDAIPool is DAIWrapper, IRewardDistributionRecipient {
         updateReward(msg.sender)
         checkStart
     {
-        require(amount > 0, 'BACDAIPool: Cannot stake 0');
+        require(amount > 0, 'BSCUSDTPool: Cannot stake 0');
         uint256 newDeposit = deposits[msg.sender].add(amount);
         require(
-            newDeposit <= 20000e18,
-            'BACDAIPool: deposit amount exceeds maximum 20000'
+            newDeposit <= 20000e6,
+            'BSCUSDTPool: deposit amount exceeds maximum 20000'
         );
         deposits[msg.sender] = newDeposit;
         super.stake(amount);
@@ -185,7 +185,7 @@ contract BACDAIPool is DAIWrapper, IRewardDistributionRecipient {
         updateReward(msg.sender)
         checkStart
     {
-        require(amount > 0, 'BACDAIPool: Cannot withdraw 0');
+        require(amount > 0, 'BSCUSDTPool: Cannot withdraw 0');
         deposits[msg.sender] = deposits[msg.sender].sub(amount);
         super.withdraw(amount);
         emit Withdrawn(msg.sender, amount);

--- a/contracts/distribution/BSCUSDTPool.sol
+++ b/contracts/distribution/BSCUSDTPool.sol
@@ -10,7 +10,7 @@ pragma solidity ^0.6.0;
 /___/ \_, //_//_/\__//_//_/\__/ \__//_/ /_\_\
      /___/
 
-* Synthetix: BSSISCASHRewards.sol
+* Synthetix: BASISCASHRewards.sol
 *
 * Docs: https://docs.synthetix.io/
 *

--- a/contracts/distribution/BSCyCRVPool.sol
+++ b/contracts/distribution/BSCyCRVPool.sol
@@ -10,7 +10,7 @@ pragma solidity ^0.6.0;
 /___/ \_, //_//_/\__//_//_/\__/ \__//_/ /_\_\
      /___/
 
-* Synthetix: BASISCASHRewards.sol
+* Synthetix: BSSISCASHRewards.sol
 *
 * Docs: https://docs.synthetix.io/
 *
@@ -62,37 +62,37 @@ import '@openzeppelin/contracts/token/ERC20/SafeERC20.sol';
 
 import '../interfaces/IRewardDistributionRecipient.sol';
 
-contract USDTWrapper {
+contract yCRVWrapper {
     using SafeMath for uint256;
     using SafeERC20 for IERC20;
 
-    IERC20 public usdt;
+    IERC20 public ycrv;
 
     uint256 private _totalSupply;
     mapping(address => uint256) private _balances;
 
-    function totalSupply() public view returns (uint256) {
+    function totalSupply() public virtual view returns (uint256) {
         return _totalSupply;
     }
 
-    function balanceOf(address account) public view returns (uint256) {
+    function balanceOf(address account) public virtual view returns (uint256) {
         return _balances[account];
     }
 
     function stake(uint256 amount) public virtual {
         _totalSupply = _totalSupply.add(amount);
         _balances[msg.sender] = _balances[msg.sender].add(amount);
-        usdt.safeTransferFrom(msg.sender, address(this), amount);
+        ycrv.safeTransferFrom(msg.sender, address(this), amount);
     }
 
     function withdraw(uint256 amount) public virtual {
         _totalSupply = _totalSupply.sub(amount);
         _balances[msg.sender] = _balances[msg.sender].sub(amount);
-        usdt.safeTransfer(msg.sender, amount);
+        ycrv.safeTransfer(msg.sender, amount);
     }
 }
 
-contract BACUSDTPool is USDTWrapper, IRewardDistributionRecipient {
+contract BSCyCRVPool is yCRVWrapper, IRewardDistributionRecipient {
     IERC20 public basisCash;
     uint256 public DURATION = 5 days;
 
@@ -112,16 +112,16 @@ contract BACUSDTPool is USDTWrapper, IRewardDistributionRecipient {
 
     constructor(
         address basisCash_,
-        address usdt_,
+        address ycrv_,
         uint256 starttime_
     ) public {
         basisCash = IERC20(basisCash_);
-        usdt = IERC20(usdt_);
+        ycrv = IERC20(ycrv_);
         starttime = starttime_;
     }
 
     modifier checkStart() {
-        require(block.timestamp >= starttime, 'BACUSDTPool: not start');
+        require(block.timestamp >= starttime, 'BSCyCRVPool: not start');
         _;
     }
 
@@ -168,11 +168,11 @@ contract BACUSDTPool is USDTWrapper, IRewardDistributionRecipient {
         updateReward(msg.sender)
         checkStart
     {
-        require(amount > 0, 'BACUSDTPool: Cannot stake 0');
+        require(amount > 0, 'BSCyCRVPool: Cannot stake 0');
         uint256 newDeposit = deposits[msg.sender].add(amount);
         require(
-            newDeposit <= 20000e6,
-            'BACUSDTPool: deposit amount exceeds maximum 20000'
+            newDeposit <= 20000e18,
+            'BSCyCRVPool: deposit amount exceeds maximum 20000'
         );
         deposits[msg.sender] = newDeposit;
         super.stake(amount);
@@ -185,7 +185,7 @@ contract BACUSDTPool is USDTWrapper, IRewardDistributionRecipient {
         updateReward(msg.sender)
         checkStart
     {
-        require(amount > 0, 'BACUSDTPool: Cannot withdraw 0');
+        require(amount > 0, 'BSCyCRVPool: Cannot withdraw 0');
         deposits[msg.sender] = deposits[msg.sender].sub(amount);
         super.withdraw(amount);
         emit Withdrawn(msg.sender, amount);

--- a/contracts/distribution/BSCyCRVPool.sol
+++ b/contracts/distribution/BSCyCRVPool.sol
@@ -10,7 +10,7 @@ pragma solidity ^0.6.0;
 /___/ \_, //_//_/\__//_//_/\__/ \__//_/ /_\_\
      /___/
 
-* Synthetix: BSSISCASHRewards.sol
+* Synthetix: BASISCASHRewards.sol
 *
 * Docs: https://docs.synthetix.io/
 *

--- a/contracts/distribution/DAIBSCLPTokenSharePool.sol
+++ b/contracts/distribution/DAIBSCLPTokenSharePool.sol
@@ -10,7 +10,7 @@ pragma solidity ^0.6.0;
 /___/ \_, //_//_/\__//_//_/\__/ \__//_/ /_\_\
      /___/
 
-* Synthetix: BASISCASHRewards.sol
+* Synthetix: BSSISCASHRewards.sol
 *
 * Docs: https://docs.synthetix.io/
 *
@@ -62,48 +62,23 @@ import '@openzeppelin/contracts/token/ERC20/SafeERC20.sol';
 
 import '../interfaces/IRewardDistributionRecipient.sol';
 
-contract yCRVWrapper {
-    using SafeMath for uint256;
-    using SafeERC20 for IERC20;
+import '../token/LPTokenWrapper.sol';
 
-    IERC20 public ycrv;
+contract DAIBSCLPTokenSharePool is
+    LPTokenWrapper,
+    IRewardDistributionRecipient
+{
+    IERC20 public basisShare;
+    uint256 public constant DURATION = 30 days;
 
-    uint256 private _totalSupply;
-    mapping(address => uint256) private _balances;
-
-    function totalSupply() public virtual view returns (uint256) {
-        return _totalSupply;
-    }
-
-    function balanceOf(address account) public virtual view returns (uint256) {
-        return _balances[account];
-    }
-
-    function stake(uint256 amount) public virtual {
-        _totalSupply = _totalSupply.add(amount);
-        _balances[msg.sender] = _balances[msg.sender].add(amount);
-        ycrv.safeTransferFrom(msg.sender, address(this), amount);
-    }
-
-    function withdraw(uint256 amount) public virtual {
-        _totalSupply = _totalSupply.sub(amount);
-        _balances[msg.sender] = _balances[msg.sender].sub(amount);
-        ycrv.safeTransfer(msg.sender, amount);
-    }
-}
-
-contract BACyCRVPool is yCRVWrapper, IRewardDistributionRecipient {
-    IERC20 public basisCash;
-    uint256 public DURATION = 5 days;
-
-    uint256 public starttime;
+    uint256 public initreward = 18479995 * 10**16; // 184,799.95 Shares
+    uint256 public starttime; // starttime TBD
     uint256 public periodFinish = 0;
     uint256 public rewardRate = 0;
     uint256 public lastUpdateTime;
     uint256 public rewardPerTokenStored;
     mapping(address => uint256) public userRewardPerTokenPaid;
     mapping(address => uint256) public rewards;
-    mapping(address => uint256) public deposits;
 
     event RewardAdded(uint256 reward);
     event Staked(address indexed user, uint256 amount);
@@ -111,18 +86,13 @@ contract BACyCRVPool is yCRVWrapper, IRewardDistributionRecipient {
     event RewardPaid(address indexed user, uint256 reward);
 
     constructor(
-        address basisCash_,
-        address ycrv_,
+        address basisShare_,
+        address lptoken_,
         uint256 starttime_
     ) public {
-        basisCash = IERC20(basisCash_);
-        ycrv = IERC20(ycrv_);
+        basisShare = IERC20(basisShare_);
+        lpt = IERC20(lptoken_);
         starttime = starttime_;
-    }
-
-    modifier checkStart() {
-        require(block.timestamp >= starttime, 'BACyCRVPool: not start');
-        _;
     }
 
     modifier updateReward(address account) {
@@ -166,15 +136,10 @@ contract BACyCRVPool is yCRVWrapper, IRewardDistributionRecipient {
         public
         override
         updateReward(msg.sender)
+        checkhalve
         checkStart
     {
-        require(amount > 0, 'BACyCRVPool: Cannot stake 0');
-        uint256 newDeposit = deposits[msg.sender].add(amount);
-        require(
-            newDeposit <= 20000e18,
-            'BACyCRVPool: deposit amount exceeds maximum 20000'
-        );
-        deposits[msg.sender] = newDeposit;
+        require(amount > 0, 'Cannot stake 0');
         super.stake(amount);
         emit Staked(msg.sender, amount);
     }
@@ -183,10 +148,10 @@ contract BACyCRVPool is yCRVWrapper, IRewardDistributionRecipient {
         public
         override
         updateReward(msg.sender)
+        checkhalve
         checkStart
     {
-        require(amount > 0, 'BACyCRVPool: Cannot withdraw 0');
-        deposits[msg.sender] = deposits[msg.sender].sub(amount);
+        require(amount > 0, 'Cannot withdraw 0');
         super.withdraw(amount);
         emit Withdrawn(msg.sender, amount);
     }
@@ -196,13 +161,29 @@ contract BACyCRVPool is yCRVWrapper, IRewardDistributionRecipient {
         getReward();
     }
 
-    function getReward() public updateReward(msg.sender) checkStart {
+    function getReward() public updateReward(msg.sender) checkhalve checkStart {
         uint256 reward = earned(msg.sender);
         if (reward > 0) {
             rewards[msg.sender] = 0;
-            basisCash.safeTransfer(msg.sender, reward);
+            basisShare.safeTransfer(msg.sender, reward);
             emit RewardPaid(msg.sender, reward);
         }
+    }
+
+    modifier checkhalve() {
+        if (block.timestamp >= periodFinish) {
+            initreward = initreward.mul(75).div(100);
+
+            rewardRate = initreward.div(DURATION);
+            periodFinish = block.timestamp.add(DURATION);
+            emit RewardAdded(initreward);
+        }
+        _;
+    }
+
+    modifier checkStart() {
+        require(block.timestamp >= starttime, 'not start');
+        _;
     }
 
     function notifyRewardAmount(uint256 reward)
@@ -223,7 +204,7 @@ contract BACyCRVPool is yCRVWrapper, IRewardDistributionRecipient {
             periodFinish = block.timestamp.add(DURATION);
             emit RewardAdded(reward);
         } else {
-            rewardRate = reward.div(DURATION);
+            rewardRate = initreward.div(DURATION);
             lastUpdateTime = starttime;
             periodFinish = starttime.add(DURATION);
             emit RewardAdded(reward);

--- a/contracts/distribution/DAIBSCLPTokenSharePool.sol
+++ b/contracts/distribution/DAIBSCLPTokenSharePool.sol
@@ -10,7 +10,7 @@ pragma solidity ^0.6.0;
 /___/ \_, //_//_/\__//_//_/\__/ \__//_/ /_\_\
      /___/
 
-* Synthetix: BSSISCASHRewards.sol
+* Synthetix: BASISCASHRewards.sol
 *
 * Docs: https://docs.synthetix.io/
 *

--- a/contracts/distribution/DAIBSSLPTokenSharePool.sol
+++ b/contracts/distribution/DAIBSSLPTokenSharePool.sol
@@ -10,7 +10,7 @@ pragma solidity ^0.6.0;
 /___/ \_, //_//_/\__//_//_/\__/ \__//_/ /_\_\
      /___/
 
-* Synthetix: BASISCASHRewards.sol
+* Synthetix: BSSISCASHRewards.sol
 *
 * Docs: https://docs.synthetix.io/
 *
@@ -64,15 +64,14 @@ import '../interfaces/IRewardDistributionRecipient.sol';
 
 import '../token/LPTokenWrapper.sol';
 
-contract DAIBACLPTokenSharePool is
+contract DAIBSSLPTokenSharePool is
     LPTokenWrapper,
     IRewardDistributionRecipient
 {
     IERC20 public basisShare;
-    uint256 public constant DURATION = 30 days;
+    uint256 public DURATION = 365 days;
 
-    uint256 public initreward = 18479995 * 10**16; // 184,799.95 Shares
-    uint256 public starttime; // starttime TBD
+    uint256 public starttime;
     uint256 public periodFinish = 0;
     uint256 public rewardRate = 0;
     uint256 public lastUpdateTime;
@@ -93,6 +92,14 @@ contract DAIBACLPTokenSharePool is
         basisShare = IERC20(basisShare_);
         lpt = IERC20(lptoken_);
         starttime = starttime_;
+    }
+
+    modifier checkStart() {
+        require(
+            block.timestamp >= starttime,
+            'DAIBSSLPTokenSharePool: not start'
+        );
+        _;
     }
 
     modifier updateReward(address account) {
@@ -136,10 +143,9 @@ contract DAIBACLPTokenSharePool is
         public
         override
         updateReward(msg.sender)
-        checkhalve
         checkStart
     {
-        require(amount > 0, 'Cannot stake 0');
+        require(amount > 0, 'DAIBSSLPTokenSharePool: Cannot stake 0');
         super.stake(amount);
         emit Staked(msg.sender, amount);
     }
@@ -148,10 +154,9 @@ contract DAIBACLPTokenSharePool is
         public
         override
         updateReward(msg.sender)
-        checkhalve
         checkStart
     {
-        require(amount > 0, 'Cannot withdraw 0');
+        require(amount > 0, 'DAIBSSLPTokenSharePool: Cannot withdraw 0');
         super.withdraw(amount);
         emit Withdrawn(msg.sender, amount);
     }
@@ -161,29 +166,13 @@ contract DAIBACLPTokenSharePool is
         getReward();
     }
 
-    function getReward() public updateReward(msg.sender) checkhalve checkStart {
+    function getReward() public updateReward(msg.sender) checkStart {
         uint256 reward = earned(msg.sender);
         if (reward > 0) {
             rewards[msg.sender] = 0;
             basisShare.safeTransfer(msg.sender, reward);
             emit RewardPaid(msg.sender, reward);
         }
-    }
-
-    modifier checkhalve() {
-        if (block.timestamp >= periodFinish) {
-            initreward = initreward.mul(75).div(100);
-
-            rewardRate = initreward.div(DURATION);
-            periodFinish = block.timestamp.add(DURATION);
-            emit RewardAdded(initreward);
-        }
-        _;
-    }
-
-    modifier checkStart() {
-        require(block.timestamp >= starttime, 'not start');
-        _;
     }
 
     function notifyRewardAmount(uint256 reward)
@@ -204,7 +193,7 @@ contract DAIBACLPTokenSharePool is
             periodFinish = block.timestamp.add(DURATION);
             emit RewardAdded(reward);
         } else {
-            rewardRate = initreward.div(DURATION);
+            rewardRate = reward.div(DURATION);
             lastUpdateTime = starttime;
             periodFinish = starttime.add(DURATION);
             emit RewardAdded(reward);

--- a/contracts/distribution/DAIBSSLPTokenSharePool.sol
+++ b/contracts/distribution/DAIBSSLPTokenSharePool.sol
@@ -10,7 +10,7 @@ pragma solidity ^0.6.0;
 /___/ \_, //_//_/\__//_//_/\__/ \__//_/ /_\_\
      /___/
 
-* Synthetix: BSSISCASHRewards.sol
+* Synthetix: BASISCASHRewards.sol
 *
 * Docs: https://docs.synthetix.io/
 *

--- a/contracts/distributor/InitialCashDistributor.sol
+++ b/contracts/distributor/InitialCashDistributor.sol
@@ -1,10 +1,10 @@
 pragma solidity ^0.6.0;
 
-import '../distribution/BACDAIPool.sol';
-import '../distribution/BACSUSDPool.sol';
-import '../distribution/BACUSDCPool.sol';
-import '../distribution/BACUSDTPool.sol';
-import '../distribution/BACyCRVPool.sol';
+import '../distribution/BSCDAIPool.sol';
+import '../distribution/BSCSUSDPool.sol';
+import '../distribution/BSCUSDCPool.sol';
+import '../distribution/BSCUSDTPool.sol';
+import '../distribution/BSCyCRVPool.sol';
 import '../interfaces/IDistributor.sol';
 
 contract InitialCashDistributor is IDistributor {
@@ -23,7 +23,7 @@ contract InitialCashDistributor is IDistributor {
         IRewardDistributionRecipient[] memory _pools,
         uint256 _totalInitialBalance
     ) public {
-        require(_pools.length != 0, 'a list of BAC pools are required');
+        require(_pools.length != 0, 'a list of BSC pools are required');
 
         cash = _cash;
         pools = _pools;

--- a/contracts/interfaces/IERC20.sol
+++ b/contracts/interfaces/IERC20.sol
@@ -1,0 +1,76 @@
+pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP. Does not include
+ * the optional functions; to access them see {ERC20Detailed}.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * IMPORTANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}

--- a/deploy.config.ts
+++ b/deploy.config.ts
@@ -1,1 +1,1 @@
-export const TREASURY_START_DATE = Date.parse('2020-12-06T00:00:00Z') / 1000; // second allocation
+export const TREASURY_START_DATE = Date.parse('2020-12-11T00:00:00Z') / 1000; // second allocation

--- a/migrations/1_initial_migration.js
+++ b/migrations/1_initial_migration.js
@@ -1,7 +1,7 @@
 const Artifactor = require('@truffle/artifactor');
 const artifactor = new Artifactor(`${__dirname}/../build/contracts`);
 
-const Migrations = artifacts.require('Migrations')
+const Migrations = artifacts.require('Migrations');
 
 const InitialArtifacts = {
   UniswapV2Factory: require('@uniswap/v2-core/build/UniswapV2Factory.json'),
@@ -10,12 +10,15 @@ const InitialArtifacts = {
 };
 
 module.exports = async function (deployer) {
-  for await ([contractName, legacyArtifact] of Object.entries(InitialArtifacts)) {
+  console.log(deployer);
+  for await ([contractName, legacyArtifact] of Object.entries(
+    InitialArtifacts
+  )) {
     await artifactor.save({
       contractName,
       ...legacyArtifact,
     });
   }
 
-  await deployer.deploy(Migrations)
-}
+  await deployer.deploy(Migrations);
+};

--- a/migrations/3_monetary_policy.js
+++ b/migrations/3_monetary_policy.js
@@ -8,9 +8,9 @@ const Share = artifacts.require('Share');
 const IERC20 = artifacts.require('IERC20');
 const MockDai = artifacts.require('MockDai');
 
-const Oracle = artifacts.require('Oracle')
-const Boardroom = artifacts.require('Boardroom')
-const Treasury = artifacts.require('Treasury')
+const Oracle = artifacts.require('Oracle');
+const Boardroom = artifacts.require('Boardroom');
+const Treasury = artifacts.require('Treasury');
 
 const UniswapV2Factory = artifacts.require('UniswapV2Factory');
 const UniswapV2Router02 = artifacts.require('UniswapV2Router02');
@@ -27,19 +27,27 @@ async function migration(deployer, network, accounts) {
     await deployer.deploy(UniswapV2Router02, uniswap.address, accounts[0]);
     uniswapRouter = await UniswapV2Router02.deployed();
   } else {
-    uniswap = await UniswapV2Factory.at(knownContracts.UniswapV2Factory[network]);
-    uniswapRouter = await UniswapV2Router02.at(knownContracts.UniswapV2Router02[network]);
+    uniswap = await UniswapV2Factory.at(
+      knownContracts.UniswapV2Factory[network]
+    );
+    uniswapRouter = await UniswapV2Router02.at(
+      knownContracts.UniswapV2Router02[network]
+    );
   }
 
-  const dai = network === 'mainnet'
-    ? await IERC20.at(knownContracts.DAI[network])
-    : await MockDai.deployed();
+  const dai =
+    network === 'mainnet'
+      ? await IERC20.at(knownContracts.DAI[network])
+      : await MockDai.deployed();
 
-  // 2. provide liquidity to BAC-DAI and BAS-DAI pair
-  // if you don't provide liquidity to BAC-DAI and BAS-DAI pair after step 1 and before step 3,
+  // 2. provide liquidity to BSC-DAI and BSS-DAI pair
+  // if you don't provide liquidity to BSC-DAI and BSS-DAI pair after step 1 and before step 3,
   //  creating Oracle will fail with NO_RESERVES error.
   const unit = web3.utils.toBN(10 ** 18).toString();
-  const max = web3.utils.toBN(10 ** 18).muln(10000).toString();
+  const max = web3.utils
+    .toBN(10 ** 18)
+    .muln(10000)
+    .toString();
 
   const cash = await Cash.deployed();
   const share = await Share.deployed();
@@ -51,29 +59,42 @@ async function migration(deployer, network, accounts) {
     approveIfNot(dai, accounts[0], uniswapRouter.address, max),
   ]);
 
-  // WARNING: msg.sender must hold enough DAI to add liquidity to BAC-DAI & BAS-DAI pools
+  // WARNING: msg.sender must hold enough DAI to add liquidity to BSC-DAI & BSS-DAI pools
   // otherwise transaction will revert
   console.log('Adding liquidity to pools');
   await uniswapRouter.addLiquidity(
-    cash.address, dai.address, unit, unit, unit, unit, accounts[0], deadline(),
+    cash.address,
+    dai.address,
+    unit,
+    unit,
+    unit,
+    unit,
+    accounts[0],
+    deadline()
   );
   await uniswapRouter.addLiquidity(
-    share.address, dai.address, unit, unit, unit, unit, accounts[0],  deadline(),
+    share.address,
+    dai.address,
+    unit,
+    unit,
+    unit,
+    unit,
+    accounts[0],
+    deadline()
   );
 
-  console.log(`DAI-BAC pair address: ${await uniswap.getPair(dai.address, cash.address)}`);
-  console.log(`DAI-BAS pair address: ${await uniswap.getPair(dai.address, share.address)}`);
+  console.log(
+    `DAI-BSC pair address: ${await uniswap.getPair(dai.address, cash.address)}`
+  );
+  console.log(
+    `DAI-BSS pair address: ${await uniswap.getPair(dai.address, share.address)}`
+  );
 
   // Deploy boardroom
   await deployer.deploy(Boardroom, cash.address, share.address);
 
   // 2. Deploy oracle for the pair between bac and dai
-  await deployer.deploy(
-    Oracle,
-    uniswap.address,
-    cash.address,
-    dai.address,
-  );
+  await deployer.deploy(Oracle, uniswap.address, cash.address, dai.address);
 
   let startTime = POOL_START_DATE;
   if (network === 'mainnet') {
@@ -87,7 +108,7 @@ async function migration(deployer, network, accounts) {
     Share.address,
     Oracle.address,
     Boardroom.address,
-    startTime,
+    startTime
   );
 }
 
@@ -97,7 +118,9 @@ async function approveIfNot(token, owner, spender, amount) {
     return;
   }
   await token.approve(spender, amount);
-  console.log(` - Approved ${token.symbol ? (await token.symbol()) : token.address}`);
+  console.log(
+    ` - Approved ${token.symbol ? await token.symbol() : token.address}`
+  );
 }
 
 function deadline() {

--- a/migrations/5_distribution_lp_pool.js
+++ b/migrations/5_distribution_lp_pool.js
@@ -6,8 +6,8 @@ const Share = artifacts.require('Share');
 const Oracle = artifacts.require('Oracle');
 const MockDai = artifacts.require('MockDai');
 
-const DAIBACLPToken_BASPool = artifacts.require('DAIBACLPTokenSharePool')
-const DAIBASLPToken_BASPool = artifacts.require('DAIBASLPTokenSharePool')
+const DAIBSCLPToken_BSSPool = artifacts.require('DAIBSCLPTokenSharePool');
+const DAIBSSLPToken_BSSPool = artifacts.require('DAIBSSLPTokenSharePool');
 
 const UniswapV2Factory = artifacts.require('UniswapV2Factory');
 
@@ -15,15 +15,34 @@ module.exports = async (deployer, network, accounts) => {
   const uniswapFactory = ['dev'].includes(network)
     ? await UniswapV2Factory.deployed()
     : await UniswapV2Factory.at(knownContracts.UniswapV2Factory[network]);
-  const dai = network === 'mainnet'
-    ? await IERC20.at(knownContracts.DAI[network])
-    : await MockDai.deployed();
+  const dai =
+    network === 'mainnet'
+      ? await IERC20.at(knownContracts.DAI[network])
+      : await MockDai.deployed();
 
   const oracle = await Oracle.deployed();
 
-  const dai_bac_lpt = await oracle.pairFor(uniswapFactory.address, Cash.address, dai.address);
-  const dai_bas_lpt = await oracle.pairFor(uniswapFactory.address, Share.address, dai.address);
+  const dai_bac_lpt = await oracle.pairFor(
+    uniswapFactory.address,
+    Cash.address,
+    dai.address
+  );
+  const dai_bas_lpt = await oracle.pairFor(
+    uniswapFactory.address,
+    Share.address,
+    dai.address
+  );
 
-  await deployer.deploy(DAIBACLPToken_BASPool, Share.address, dai_bac_lpt, POOL_START_DATE);
-  await deployer.deploy(DAIBASLPToken_BASPool, Share.address, dai_bas_lpt, POOL_START_DATE);
+  await deployer.deploy(
+    DAIBSCLPToken_BSSPool,
+    Share.address,
+    dai_bac_lpt,
+    POOL_START_DATE
+  );
+  await deployer.deploy(
+    DAIBSSLPToken_BSSPool,
+    Share.address,
+    dai_bas_lpt,
+    POOL_START_DATE
+  );
 };

--- a/migrations/5_distribution_lp_pool.js
+++ b/migrations/5_distribution_lp_pool.js
@@ -5,6 +5,7 @@ const Cash = artifacts.require('Cash');
 const Share = artifacts.require('Share');
 const Oracle = artifacts.require('Oracle');
 const MockDai = artifacts.require('MockDai');
+const IERC20 = artifacts.require('IERC20');
 
 const DAIBSCLPToken_BSSPool = artifacts.require('DAIBSCLPTokenSharePool');
 const DAIBSSLPToken_BSSPool = artifacts.require('DAIBSSLPTokenSharePool');

--- a/migrations/6_bac_reward_distributor.js
+++ b/migrations/6_bac_reward_distributor.js
@@ -1,35 +1,41 @@
-const { bacPools, INITIAL_BAC_FOR_POOLS } = require('./pools');
+const { bacPools, INITIAL_BSC_FOR_POOLS } = require('./pools');
 
 // Pools
 // deployed first
-const Cash = artifacts.require('Cash')
+const Cash = artifacts.require('Cash');
 const InitialCashDistributor = artifacts.require('InitialCashDistributor');
 
 // ============ Main Migration ============
 
 module.exports = async (deployer, network, accounts) => {
   const unit = web3.utils.toBN(10 ** 18);
-  const initialCashAmount = unit.muln(INITIAL_BAC_FOR_POOLS).toString();
+  const initialCashAmount = unit.muln(INITIAL_BSC_FOR_POOLS).toString();
 
   const cash = await Cash.deployed();
-  const pools = bacPools.map(({contractName}) => artifacts.require(contractName));
+  const pools = bacPools.map(({ contractName }) =>
+    artifacts.require(contractName)
+  );
 
   await deployer.deploy(
     InitialCashDistributor,
     cash.address,
-    pools.map(p => p.address),
-    initialCashAmount,
+    pools.map((p) => p.address),
+    initialCashAmount
   );
   const distributor = await InitialCashDistributor.deployed();
 
-  console.log(`Setting distributor to InitialCashDistributor (${distributor.address})`);
+  console.log(
+    `Setting distributor to InitialCashDistributor (${distributor.address})`
+  );
   for await (const poolInfo of pools) {
-    const pool = await poolInfo.deployed()
+    const pool = await poolInfo.deployed();
     await pool.setRewardDistribution(distributor.address);
   }
 
   await cash.mint(distributor.address, initialCashAmount);
-  console.log(`Deposited ${INITIAL_BAC_FOR_POOLS} BAC to InitialCashDistributor.`);
+  console.log(
+    `Deposited ${INITIAL_BSC_FOR_POOLS} BSC to InitialCashDistributor.`
+  );
 
   await distributor.distribute();
-}
+};

--- a/migrations/7_bas_reward_distributor.js
+++ b/migrations/7_bas_reward_distributor.js
@@ -1,7 +1,7 @@
 const {
   basPools,
-  INITIAL_BAS_FOR_DAI_BAC,
-  INITIAL_BAS_FOR_DAI_BAS,
+  INITIAL_BSS_FOR_DAI_BSC,
+  INITIAL_BSS_FOR_DAI_BSS,
 } = require('./pools');
 
 // Pools
@@ -13,31 +13,39 @@ const InitialShareDistributor = artifacts.require('InitialShareDistributor');
 
 async function migration(deployer, network, accounts) {
   const unit = web3.utils.toBN(10 ** 18);
-  const totalBalanceForDAIBAC = unit.muln(INITIAL_BAS_FOR_DAI_BAC)
-  const totalBalanceForDAIBAS = unit.muln(INITIAL_BAS_FOR_DAI_BAS)
-  const totalBalance = totalBalanceForDAIBAC.add(totalBalanceForDAIBAS);
+  const totalBalanceForDAIBSC = unit.muln(INITIAL_BSS_FOR_DAI_BSC);
+  const totalBalanceForDAIBSS = unit.muln(INITIAL_BSS_FOR_DAI_BSS);
+  const totalBalance = totalBalanceForDAIBSC.add(totalBalanceForDAIBSS);
 
   const share = await Share.deployed();
 
-  const lpPoolDAIBAC = artifacts.require(basPools.DAIBAC.contractName);
-  const lpPoolDAIBAS = artifacts.require(basPools.DAIBAS.contractName);
+  const lpPoolDAIBSC = artifacts.require(basPools.DAIBSC.contractName);
+  const lpPoolDAIBSS = artifacts.require(basPools.DAIBSS.contractName);
 
   await deployer.deploy(
     InitialShareDistributor,
     share.address,
-    lpPoolDAIBAC.address,
-    totalBalanceForDAIBAC.toString(),
-    lpPoolDAIBAS.address,
-    totalBalanceForDAIBAS.toString(),
+    lpPoolDAIBSC.address,
+    totalBalanceForDAIBSC.toString(),
+    lpPoolDAIBSS.address,
+    totalBalanceForDAIBSS.toString()
   );
   const distributor = await InitialShareDistributor.deployed();
 
   await share.mint(distributor.address, totalBalance.toString());
-  console.log(`Deposited ${INITIAL_BAS_FOR_DAI_BAC} BAS to InitialShareDistributor.`);
+  console.log(
+    `Deposited ${INITIAL_BSS_FOR_DAI_BSC} BSS to InitialShareDistributor.`
+  );
 
-  console.log(`Setting distributor to InitialShareDistributor (${distributor.address})`);
-  await lpPoolDAIBAC.deployed().then(pool => pool.setRewardDistribution(distributor.address));
-  await lpPoolDAIBAS.deployed().then(pool => pool.setRewardDistribution(distributor.address));
+  console.log(
+    `Setting distributor to InitialShareDistributor (${distributor.address})`
+  );
+  await lpPoolDAIBSC
+    .deployed()
+    .then((pool) => pool.setRewardDistribution(distributor.address));
+  await lpPoolDAIBSS
+    .deployed()
+    .then((pool) => pool.setRewardDistribution(distributor.address));
 
   await distributor.distribute();
 }

--- a/migrations/pools.js
+++ b/migrations/pools.js
@@ -1,28 +1,28 @@
 // https://docs.basis.cash/mechanisms/yield-farming
-const INITIAL_BAC_FOR_POOLS = 50000;
-const INITIAL_BAS_FOR_DAI_BAC = 750000;
-const INITIAL_BAS_FOR_DAI_BAS = 250000;
+const INITIAL_BSC_FOR_POOLS = 50000;
+const INITIAL_BSS_FOR_DAI_BSC = 750000;
+const INITIAL_BSS_FOR_DAI_BSS = 250000;
 
-const POOL_START_DATE = Date.parse('2020-11-30T00:00:00Z') / 1000;
+const POOL_START_DATE = Date.parse('2020-12-05T00:00:00Z') / 1000;
 
 const bacPools = [
-  { contractName: 'BACDAIPool', token: 'DAI' },
-  { contractName: 'BACSUSDPool', token: 'SUSD' },
-  { contractName: 'BACUSDCPool', token: 'USDC' },
-  { contractName: 'BACUSDTPool', token: 'USDT' },
-  { contractName: 'BACyCRVPool', token: 'yCRV' },
+  { contractName: 'BSCDAIPool', token: 'DAI' },
+  { contractName: 'BSCSUSDPool', token: 'SUSD' },
+  { contractName: 'BSCUSDCPool', token: 'USDC' },
+  { contractName: 'BSCUSDTPool', token: 'USDT' },
+  { contractName: 'BSCyCRVPool', token: 'yCRV' },
 ];
 
 const basPools = {
-  DAIBAC: { contractName: 'DAIBACLPTokenSharePool', token: 'DAI_BAC-LPv2' },
-  DAIBAS: { contractName: 'DAIBASLPTokenSharePool', token: 'DAI_BAS-LPv2' },
-}
+  DAIBSC: { contractName: 'DAIBSCLPTokenSharePool', token: 'DAI_BSC-LPv2' },
+  DAIBSS: { contractName: 'DAIBSSLPTokenSharePool', token: 'DAI_BSS-LPv2' },
+};
 
 module.exports = {
   POOL_START_DATE,
-  INITIAL_BAC_FOR_POOLS,
-  INITIAL_BAS_FOR_DAI_BAC,
-  INITIAL_BAS_FOR_DAI_BAS,
+  INITIAL_BSC_FOR_POOLS,
+  INITIAL_BSS_FOR_DAI_BSC,
+  INITIAL_BSS_FOR_DAI_BSS,
   bacPools,
   basPools,
 };

--- a/scripts/migrate-treasury.ts
+++ b/scripts/migrate-treasury.ts
@@ -70,7 +70,7 @@ async function main() {
 
   console.log('\n===================================================\n');
 
-  console.log('=> RBAC\n');
+  console.log('=> RBSC\n');
 
   tx = await newBoardroom
     .connect(operator)

--- a/test/Treasury.test.ts
+++ b/test/Treasury.test.ts
@@ -211,7 +211,9 @@ describe('Treasury', () => {
       const cashPrice = await oracle.consult(cash.address, ETH);
       const treasuryReserve = await treasury.getReserve();
       const cashSupply = (await cash.totalSupply()).sub(treasuryReserve);
-      const expectedSeigniorage = cashSupply.mul(cashPrice.sub(ETH)).div(ETH);
+      const percentage = cashPrice.sub(ETH);
+      const cappedPercentage = percentage > ETH ? ETH : percentage;
+      const expectedSeigniorage = cashSupply.mul(cappedPercentage).div(ETH);
 
       const tx = await treasury.allocateSeigniorage();
       const blocktime = await latestBlocktime(provider);
@@ -238,7 +240,9 @@ describe('Treasury', () => {
       const cashPrice = await oracle.consult(cash.address, ETH);
       const treasuryReserve = await treasury.getReserve();
       const cashSupply = (await cash.totalSupply()).sub(treasuryReserve);
-      const expectedSeigniorage = cashSupply.mul(cashPrice.sub(ETH)).div(ETH);
+      const percentage = cashPrice.sub(ETH);
+      const cappedPercentage = percentage > ETH ? ETH : percentage;
+      const expectedSeigniorage = cashSupply.mul(cappedPercentage).div(ETH);
 
       const tx = await treasury.allocateSeigniorage();
       const blocktime = await latestBlocktime(provider);

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -42,7 +42,7 @@ module.exports = {
     // tab if you use this network and you must also set the `host`, `port` and `network_id`
     // options below to some value.
     //
-    development: {
+    dev: {
       host: '127.0.0.1', // Localhost (default: none)
       port: 8545, // Standard Ethereum port (default: none)
       network_id: '5777',
@@ -95,4 +95,4 @@ module.exports = {
       // }
     },
   },
-}
+};


### PR DESCRIPTION
This PR alters the Treasury minting rules so that at-most, the supply of Cash will double every 24 hours. This allows the expansion mechanism to reach a target supply in logarithmic time, without overly flooding the market on any particular day. 

In order to avoid collision with the original protocol's tokens, tickers have been changed to be BSC, BSS, and BSB. 

The farming start date has been set to Dec 5th at 00:00 UTC, the same time that farming ends for the original protocol. This way LPs can farm both protocols without compromise.

The Treasury start date has been set to Dec 11th at 00:00 UTC in the first deployment, but will be changed to Dec 14th at 00:00 UTC via a migration shortly. 
